### PR TITLE
I've fixed the image paths in `index.html`.

### DIFF
--- a/index.html
+++ b/index.html
@@ -576,10 +576,7 @@
                     <h1 class="font-display">
                         Hello, I'm <span style="color: var(--accent-primary);">Diwakar</span>
                     </h1>
-                    <picture>
-                        <source srcset="https://via.placeholder.com/600x400.webp?text=Home+Banner" type="image/webp">
-                        <img src="images/home.png" alt="Home Banner" class="hero-main-image" />
-                    </picture>
+                    <img src="images/home.png" alt="Home Banner" class="hero-main-image" />
 
                     <p class="subtitle">
                         BIT Student & Computer Support Professional with expertise in system administration and technical communication.
@@ -604,10 +601,7 @@
             
             <div class="grid grid-cols-2">
                 <div class="project-card fade-in">
-                    <picture>
-                        <source srcset="https://via.placeholder.com/350x200.webp?text=Police+Exam+Prep" type="image/webp">
-                        <img src="images/police-exam-prep.png" alt="Police Exam Prep Project" class="project-image" />
-                    </picture>
+                    <img src="images/police-exam-prep.png" alt="Police Exam Prep Project" class="project-image" />
                     <div class="project-content">
                         <h3 class="project-title">Police Exam Prep</h3>
                         <p class="project-description">
@@ -651,10 +645,7 @@
 
             <div class="about-content">
                 <div class="fade-in about-image-container">
-                    <picture>
-                        <source srcset="https://via.placeholder.com/180x180.webp?text=About+Me" type="image/webp">
-                        <img src="images/aboutme.png" alt="About Diwakar Ray Yadav" class="about-image" />
-                    </picture>
+                    <img src="images/aboutme.png" alt="About Diwakar Ray Yadav" class="about-image" />
                 </div>
                 
                 <div class="fade-in">


### PR DESCRIPTION
The images on your portfolio website weren't displaying correctly because the HTML was using the `<picture>` element with `<source>` tags pointing to placeholder images.

I removed the `<picture>` and `<source>` tags, leaving only the `<img>` tags that correctly reference the local PNG images. This should ensure that your intended portfolio images are now displayed.