### PR TITLE
feat: Pinterest blog thumbnails + fix dark/light toggle cascade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ portfolio-os/out/
 .qa-screens/
 .live-qa/
 .playwright-mcp/
+.mimosa/
 docs/
 *.log

--- a/blog/ai-myths-tested/index.html
+++ b/blog/ai-myths-tested/index.html
@@ -67,7 +67,7 @@
     <meta property="og:description" content="Five common AI claims put to a hands-on test, with honest results: which held up, which failed, and what the gap between demo and reality really is.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://diwakaryadav.com.np/blog/ai-myths-tested/">
-    <meta property="og:image" content="https://diwakaryadav.com.np/images/blog-ai-myths-tested.svg">
+    <meta property="og:image" content="https://i.pinimg.com/originals/74/5e/83/745e832c4c5e6a34b51815555f3983f2">
     <meta property="og:image:alt" content="AI Myths I Tested: 5 Claims, and 3 Were Flat-Out False">
     <meta property="article:published_time" content="2026-07-20">
     <meta property="article:modified_time" content="2026-08-09">
@@ -77,7 +77,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="AI Myths I Tested: 5 Claims, and 3 Were Flat-Out False">
     <meta name="twitter:description" content="Five common AI claims put to a hands-on test, with honest results: which held up, which failed, and what the gap between demo and reality really is.">
-    <meta name="twitter:image" content="https://diwakaryadav.com.np/images/blog-ai-myths-tested.svg">
+    <meta name="twitter:image" content="https://i.pinimg.com/originals/74/5e/83/745e832c4c5e6a34b51815555f3983f2">
 
     <script type="application/ld+json">
         {
@@ -86,7 +86,7 @@
             "headline": "AI Myths I Tested: 5 Claims, and 3 Were Flat-Out False",
             "alternativeHeadline": "I took five things people say about AI and actually ran them. The results were less flattering than the hype.",
             "description": "Five common AI claims put to a hands-on test, with honest results: which held up, which failed, and what the gap between demo and reality really is.",
-            "image": ["https://diwakaryadav.com.np/images/blog-ai-myths-tested.svg"],
+            "image": ["https://i.pinimg.com/originals/74/5e/83/745e832c4c5e6a34b51815555f3983f2"],
             "mainEntityOfPage": { "@type": "WebPage", "@id": "https://diwakaryadav.com.np/blog/ai-myths-tested/" },
             "datePublished": "2026-07-20",
             "dateModified": "2026-08-09",

--- a/blog/best-ai-coding-assistants/index.html
+++ b/blog/best-ai-coding-assistants/index.html
@@ -67,7 +67,7 @@
     <meta property="og:description" content="A hands-on comparison of 7 AI coding assistants tested on the same real tasks, with honest strengths, weaknesses, and a final verdict.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://diwakaryadav.com.np/blog/best-ai-coding-assistants/">
-    <meta property="og:image" content="https://diwakaryadav.com.np/images/blog-best-ai-coding-assistants.svg">
+    <meta property="og:image" content="https://i.pinimg.com/originals/68/1b/6a/681b6ade1c1f80248cf2a0b52a8db937">
     <meta property="og:image:alt" content="I Tested 7 AI Coding Assistants So You Don't Have To">
     <meta property="article:published_time" content="2026-05-18">
     <meta property="article:modified_time" content="2026-08-09">
@@ -77,7 +77,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="I Tested 7 AI Coding Assistants So You Don't Have To">
     <meta name="twitter:description" content="A hands-on comparison of 7 AI coding assistants tested on the same real tasks, with honest strengths, weaknesses, and a final verdict.">
-    <meta name="twitter:image" content="https://diwakaryadav.com.np/images/blog-best-ai-coding-assistants.svg">
+    <meta name="twitter:image" content="https://i.pinimg.com/originals/68/1b/6a/681b6ade1c1f80248cf2a0b52a8db937">
 
     <script type="application/ld+json">
         {
@@ -86,7 +86,7 @@
             "headline": "I Tested 7 AI Coding Assistants So You Don't Have To",
             "alternativeHeadline": "I gave the same ugly bug to seven assistants. Three nailed it. Two made it worse. Here is the scoreboard.",
             "description": "A hands-on comparison of 7 AI coding assistants tested on the same real tasks, with honest strengths, weaknesses, and a final verdict.",
-            "image": ["https://diwakaryadav.com.np/images/blog-best-ai-coding-assistants.svg"],
+            "image": ["https://i.pinimg.com/originals/68/1b/6a/681b6ade1c1f80248cf2a0b52a8db937"],
             "mainEntityOfPage": { "@type": "WebPage", "@id": "https://diwakaryadav.com.np/blog/best-ai-coding-assistants/" },
             "datePublished": "2026-05-18",
             "dateModified": "2026-08-09",

--- a/blog/building-in-public-kathmandu/index.html
+++ b/blog/building-in-public-kathmandu/index.html
@@ -67,7 +67,7 @@
     <meta property="og:description" content="A year-one retrospective on building and shipping AI projects in public from Kathmandu, with honest lessons on consistency, audience, and shipping ugly.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://diwakaryadav.com.np/blog/building-in-public-kathmandu/">
-    <meta property="og:image" content="https://diwakaryadav.com.np/images/blog-building-in-public-kathmandu.svg">
+    <meta property="og:image" content="https://i.pinimg.com/originals/6e/52/49/6e5249195ddc843b50885dd24e7a515f">
     <meta property="og:image:alt" content="Building in Public from Kathmandu: One Year of Shipping AI Projects">
     <meta property="article:published_time" content="2026-07-04">
     <meta property="article:modified_time" content="2026-08-09">
@@ -77,7 +77,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Building in Public from Kathmandu: One Year of Shipping AI Projects">
     <meta name="twitter:description" content="A year-one retrospective on building and shipping AI projects in public from Kathmandu, with honest lessons on consistency, audience, and shipping ugly.">
-    <meta name="twitter:image" content="https://diwakaryadav.com.np/images/blog-building-in-public-kathmandu.svg">
+    <meta name="twitter:image" content="https://i.pinimg.com/originals/6e/52/49/6e5249195ddc843b50885dd24e7a515f">
 
     <script type="application/ld+json">
         {
@@ -86,7 +86,7 @@
             "headline": "Building in Public from Kathmandu: One Year of Shipping AI Projects",
             "alternativeHeadline": "No Silicon Valley zip code, no funding, just a laptop and a habit of shipping. Here is what a year taught me.",
             "description": "A year-one retrospective on building and shipping AI projects in public from Kathmandu, with honest lessons on consistency, audience, and shipping ugly.",
-            "image": ["https://diwakaryadav.com.np/images/blog-building-in-public-kathmandu.svg"],
+            "image": ["https://i.pinimg.com/originals/6e/52/49/6e5249195ddc843b50885dd24e7a515f"],
             "mainEntityOfPage": { "@type": "WebPage", "@id": "https://diwakaryadav.com.np/blog/building-in-public-kathmandu/" },
             "datePublished": "2026-07-04",
             "dateModified": "2026-08-09",

--- a/blog/claude-vs-chatgpt-vs-gemini/index.html
+++ b/blog/claude-vs-chatgpt-vs-gemini/index.html
@@ -67,7 +67,7 @@
     <meta property="og:description" content="A long-term, hands-on comparison of Claude, ChatGPT, and Gemini after six months of daily use, covering writing, coding, search, and honesty.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://diwakaryadav.com.np/blog/claude-vs-chatgpt-vs-gemini/">
-    <meta property="og:image" content="https://diwakaryadav.com.np/images/blog-claude-vs-chatgpt-vs-gemini.svg">
+    <meta property="og:image" content="https://i.pinimg.com/originals/ba/0e/3d/ba0e3d11749de35d9e869a542caccfa2">
     <meta property="og:image:alt" content="Claude vs ChatGPT vs Gemini: 6 Months of Daily Use, Real Differences">
     <meta property="article:published_time" content="2026-06-02">
     <meta property="article:modified_time" content="2026-08-09">
@@ -77,7 +77,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Claude vs ChatGPT vs Gemini: 6 Months of Daily Use, Real Differences">
     <meta name="twitter:description" content="A long-term, hands-on comparison of Claude, ChatGPT, and Gemini after six months of daily use, covering writing, coding, search, and honesty.">
-    <meta name="twitter:image" content="https://diwakaryadav.com.np/images/blog-claude-vs-chatgpt-vs-gemini.svg">
+    <meta name="twitter:image" content="https://i.pinimg.com/originals/ba/0e/3d/ba0e3d11749de35d9e869a542caccfa2">
 
     <script type="application/ld+json">
         {
@@ -86,7 +86,7 @@
             "headline": "Claude vs ChatGPT vs Gemini: 6 Months of Daily Use, Real Differences",
             "alternativeHeadline": "After half a year of living inside all three, the differences are smaller than the marketing and bigger than you think.",
             "description": "A long-term, hands-on comparison of Claude, ChatGPT, and Gemini after six months of daily use, covering writing, coding, search, and honesty.",
-            "image": ["https://diwakaryadav.com.np/images/blog-claude-vs-chatgpt-vs-gemini.svg"],
+            "image": ["https://i.pinimg.com/originals/ba/0e/3d/ba0e3d11749de35d9e869a542caccfa2"],
             "mainEntityOfPage": { "@type": "WebPage", "@id": "https://diwakaryadav.com.np/blog/claude-vs-chatgpt-vs-gemini/" },
             "datePublished": "2026-06-02",
             "dateModified": "2026-08-09",

--- a/blog/free-ai-stack/index.html
+++ b/blog/free-ai-stack/index.html
@@ -67,7 +67,7 @@
     <meta property="og:description" content="The exact set of free AI tools used daily for writing, coding, research, and image work, with honest notes on where the free tier stops being enough.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://diwakaryadav.com.np/blog/free-ai-stack/">
-    <meta property="og:image" content="https://diwakaryadav.com.np/images/blog-free-ai-stack.svg">
+    <meta property="og:image" content="https://i.pinimg.com/originals/3b/8c/b3/3b8cb33121e1bba3b2fd189404bd65f5">
     <meta property="og:image:alt" content="The Free AI Stack: Everything I Use Daily That Costs $0">
     <meta property="article:published_time" content="2026-06-18">
     <meta property="article:modified_time" content="2026-08-09">
@@ -77,7 +77,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="The Free AI Stack: Everything I Use Daily That Costs $0">
     <meta name="twitter:description" content="The exact set of free AI tools used daily for writing, coding, research, and image work, with honest notes on where the free tier stops being enough.">
-    <meta name="twitter:image" content="https://diwakaryadav.com.np/images/blog-free-ai-stack.svg">
+    <meta name="twitter:image" content="https://i.pinimg.com/originals/3b/8c/b3/3b8cb33121e1bba3b2fd189404bd65f5">
 
     <script type="application/ld+json">
         {
@@ -86,7 +86,7 @@
             "headline": "The Free AI Stack: Everything I Use Daily That Costs $0",
             "alternativeHeadline": "My whole daily AI workflow runs on free tiers. Here is the exact stack, and where the free line breaks.",
             "description": "The exact set of free AI tools used daily for writing, coding, research, and image work, with honest notes on where the free tier stops being enough.",
-            "image": ["https://diwakaryadav.com.np/images/blog-free-ai-stack.svg"],
+            "image": ["https://i.pinimg.com/originals/3b/8c/b3/3b8cb33121e1bba3b2fd189404bd65f5"],
             "mainEntityOfPage": { "@type": "WebPage", "@id": "https://diwakaryadav.com.np/blog/free-ai-stack/" },
             "datePublished": "2026-06-18",
             "dateModified": "2026-08-09",

--- a/blog/index.html
+++ b/blog/index.html
@@ -45,7 +45,7 @@
 
     <!-- Critical CSS: variables, reset, header, layout -->
     <style>
-        :root {
+        :root, html[data-theme="light"] {
             --bg-primary: #FEFAE0;
             --bg-secondary: #F4F3EE;
             --text-primary: #2D3748;
@@ -127,13 +127,13 @@
         content="Read practical posts about prompt engineering, AI tools, LLMs, and automation workflows.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://diwakaryadav.com.np/blog/">
-    <meta property="og:image" content="https://diwakaryadav.com.np/images/blog-index.svg">
+    <meta property="og:image" content="https://i.pinimg.com/originals/2c/52/5f/2c525f08e83bb1a1989df8fd69ecf5f8.jpg">
     <meta property="og:image:alt" content="Diwakar Ray Yadav AI blog">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="AI Blog, Prompting Tips, and Free AI Tools | Diwakar Ray Yadav">
     <meta name="twitter:description"
         content="Read practical posts about prompt engineering, AI tools, LLMs, and automation workflows.">
-    <meta name="twitter:image" content="https://diwakaryadav.com.np/images/blog-index.svg">
+    <meta name="twitter:image" content="https://i.pinimg.com/originals/2c/52/5f/2c525f08e83bb1a1989df8fd69ecf5f8.jpg">
 
     <script type="application/ld+json">
         {
@@ -196,10 +196,20 @@
             width: 100%;
             height: 200px;
             background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-secondary) 100%);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 4rem;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .blog-card-image img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            display: block;
+            transition: transform 0.4s ease;
+        }
+
+        a.blog-card:hover .blog-card-image img {
+            transform: scale(1.05);
         }
 
         .blog-card-content {
@@ -344,7 +354,7 @@
             <div class="blog-grid">
                 <!-- Blog Post 2 - Trending LLMs (Newest) -->
                 <a href="trending-llms/" class="blog-card fade-in">
-                    <div class="blog-card-image">🚀</div>
+                    <div class="blog-card-image"><img src="https://i.pinimg.com/originals/2c/52/5f/2c525f08e83bb1a1989df8fd69ecf5f8.jpg" alt="Abstract warm shapes representing AI and language models" loading="lazy" onerror="this.style.display='none'"></div>
                     <div class="blog-card-content">
                         <span class="blog-card-tag">AI & Tools</span>
                         <h2 class="blog-card-title">Best Free AI Tools, LLMs, and Agent Platforms in 2026</h2>
@@ -361,7 +371,7 @@
 
                 <!-- Blog Post 1 - Prompting Tips -->
                 <a href="prompting-tips/" class="blog-card fade-in">
-                    <div class="blog-card-image">🤖</div>
+                    <div class="blog-card-image"><img src="https://i.pinimg.com/originals/23/03/a6/2303a67089c546ffbfb512fc21bd6958.jpg" alt="Bauhaus sun over horizontal lines representing clean prompt structure" loading="lazy" onerror="this.style.display='none'"></div>
                     <div class="blog-card-content">
                         <span class="blog-card-tag">AI & Prompting</span>
                         <h2 class="blog-card-title">12 AI Prompting Tips for Better ChatGPT and Claude Results</h2>
@@ -378,7 +388,7 @@
 
                 <!-- New Post - Open vs Closed -->
                 <a href="open-vs-closed-models/" class="blog-card fade-in">
-                    <div class="blog-card-image">🔓</div>
+                    <div class="blog-card-image"><img src="https://i.pinimg.com/originals/e4/b7/a1/e4b7a140fe7b7c584b5abeb36372754f.jpg" alt="Sun setting over ocean representing open versus closed AI models" loading="lazy" onerror="this.style.display='none'"></div>
                     <div class="blog-card-content">
                         <span class="blog-card-tag">AI & Strategy</span>
                         <h2 class="blog-card-title">Open-Weight vs Closed AI Models: Which Should You Actually Use?</h2>
@@ -394,7 +404,7 @@
 
                 <!-- New Post - Coding Assistants -->
                 <a href="best-ai-coding-assistants/" class="blog-card fade-in">
-                    <div class="blog-card-image">💻</div>
+                    <div class="blog-card-image"><img src="https://i.pinimg.com/originals/68/1b/6a/681b6ade1c1f80248cf2a0b52a8db937.jpg" alt="Abstract mountain shapes representing AI coding tools" loading="lazy" onerror="this.style.display='none'"></div>
                     <div class="blog-card-content">
                         <span class="blog-card-tag">AI & Tools</span>
                         <h2 class="blog-card-title">I Tested 7 AI Coding Assistants So You Don't Have To</h2>
@@ -410,7 +420,7 @@
 
                 <!-- New Post - Run LLM locally -->
                 <a href="run-llm-locally/" class="blog-card fade-in">
-                    <div class="blog-card-image">💾</div>
+                    <div class="blog-card-image"><img src="https://i.pinimg.com/originals/b5/ce/73/b5ce7371503ba2673115ef209e0e4052.jpg" alt="Potted plant on warm cream background representing local LLM hosting" loading="lazy" onerror="this.style.display='none'"></div>
                     <div class="blog-card-content">
                         <span class="blog-card-tag">AI & Tutorials</span>
                         <h2 class="blog-card-title">How to Run an LLM on a Normal Laptop (No GPU, No PhD)</h2>
@@ -426,7 +436,7 @@
 
                 <!-- New Post - Claude vs ChatGPT vs Gemini -->
                 <a href="claude-vs-chatgpt-vs-gemini/" class="blog-card fade-in">
-                    <div class="blog-card-image">⚖️</div>
+                    <div class="blog-card-image"><img src="https://i.pinimg.com/originals/ba/0e/3d/ba0e3d11749de35d9e869a542caccfa2.jpg" alt="Mountains with red sun representing LLM comparison" loading="lazy" onerror="this.style.display='none'"></div>
                     <div class="blog-card-content">
                         <span class="blog-card-tag">AI & Comparison</span>
                         <h2 class="blog-card-title">Claude vs ChatGPT vs Gemini: 6 Months of Daily Use, Real Differences</h2>
@@ -442,7 +452,7 @@
 
                 <!-- New Post - What are AI agents -->
                 <a href="what-are-ai-agents/" class="blog-card fade-in">
-                    <div class="blog-card-image">🤖</div>
+                    <div class="blog-card-image"><img src="https://i.pinimg.com/originals/f8/ec/8a/f8ec8a634ba7c7db84c1e0de011ec1e0.jpg" alt="Three trees representing AI agents in motion" loading="lazy" onerror="this.style.display='none'"></div>
                     <div class="blog-card-content">
                         <span class="blog-card-tag">AI & Strategy</span>
                         <h2 class="blog-card-title">AI Agents Are Quietly Breaking the Old 'App' Model</h2>
@@ -458,7 +468,7 @@
 
                 <!-- New Post - Free AI stack -->
                 <a href="free-ai-stack/" class="blog-card fade-in">
-                    <div class="blog-card-image">🆓</div>
+                    <div class="blog-card-image"><img src="https://i.pinimg.com/originals/3b/8c/b3/3b8cb33121e1bba3b2fd189404bd65f5.jpg" alt="Botanical illustration representing a free AI tool stack" loading="lazy" onerror="this.style.display='none'"></div>
                     <div class="blog-card-content">
                         <span class="blog-card-tag">AI & Tools</span>
                         <h2 class="blog-card-title">The Free AI Stack: Everything I Use Daily That Costs $0</h2>
@@ -474,7 +484,7 @@
 
                 <!-- New Post - Prompt engineering dead -->
                 <a href="is-prompt-engineering-dead/" class="blog-card fade-in">
-                    <div class="blog-card-image">🪦</div>
+                    <div class="blog-card-image"><img src="https://i.pinimg.com/originals/fc/e0/0a/fce00a744394654ea05c69fa4ca54096.jpg" alt="Quiet autumn landscape with bench representing the end of prompt engineering era" loading="lazy" onerror="this.style.display='none'"></div>
                     <div class="blog-card-content">
                         <span class="blog-card-tag">AI & Prompting</span>
                         <h2 class="blog-card-title">Prompt Engineering Is Dead. Here's What Replaced It</h2>
@@ -490,7 +500,7 @@
 
                 <!-- New Post - Building in public -->
                 <a href="building-in-public-kathmandu/" class="blog-card fade-in">
-                    <div class="blog-card-image">🏔️</div>
+                    <div class="blog-card-image"><img src="https://i.pinimg.com/originals/6e/52/49/6e5249195ddc843b50885dd24e7a515f.jpg" alt="Dunes at golden hour with solitary figure representing building in public from Kathmandu" loading="lazy" onerror="this.style.display='none'"></div>
                     <div class="blog-card-content">
                         <span class="blog-card-tag">Builder's Log</span>
                         <h2 class="blog-card-title">Building in Public from Kathmandu: One Year of Shipping AI Projects</h2>
@@ -506,7 +516,7 @@
 
                 <!-- New Post - AI myths tested -->
                 <a href="ai-myths-tested/" class="blog-card fade-in">
-                    <div class="blog-card-image">🧪</div>
+                    <div class="blog-card-image"><img src="https://i.pinimg.com/originals/74/5e/83/745e832c4c5e6a34b51815555f3983f2.jpg" alt="Warm sunset illustration representing AI myths put to the test" loading="lazy" onerror="this.style.display='none'"></div>
                     <div class="blog-card-content">
                         <span class="blog-card-tag">AI & Reality</span>
                         <h2 class="blog-card-title">AI Myths I Tested: 5 Claims, and 3 Were Flat-Out False</h2>

--- a/blog/is-prompt-engineering-dead/index.html
+++ b/blog/is-prompt-engineering-dead/index.html
@@ -67,7 +67,7 @@
     <meta property="og:description" content="Why classic prompt engineering is fading and what replaced it: context engineering, evaluation, and knowing which model to use.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://diwakaryadav.com.np/blog/is-prompt-engineering-dead/">
-    <meta property="og:image" content="https://diwakaryadav.com.np/images/blog-is-prompt-engineering-dead.svg">
+    <meta property="og:image" content="https://i.pinimg.com/originals/fc/e0/0a/fce00a744394654ea05c69fa4ca54096">
     <meta property="og:image:alt" content="Prompt Engineering Is Dead. Here's What Replaced It">
     <meta property="article:published_time" content="2026-06-26">
     <meta property="article:modified_time" content="2026-08-09">
@@ -77,7 +77,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Prompt Engineering Is Dead. Here's What Replaced It">
     <meta name="twitter:description" content="Why classic prompt engineering is fading and what replaced it: context engineering, evaluation, and knowing which model to use.">
-    <meta name="twitter:image" content="https://diwakaryadav.com.np/images/blog-is-prompt-engineering-dead.svg">
+    <meta name="twitter:image" content="https://i.pinimg.com/originals/fc/e0/0a/fce00a744394654ea05c69fa4ca54096">
 
     <script type="application/ld+json">
         {
@@ -86,7 +86,7 @@
             "headline": "Prompt Engineering Is Dead. Here's What Replaced It",
             "alternativeHeadline": "The skill did not vanish. It grew up, got a new name, and moved one level up.",
             "description": "Why classic prompt engineering is fading and what replaced it: context engineering, evaluation, and knowing which model to use.",
-            "image": ["https://diwakaryadav.com.np/images/blog-is-prompt-engineering-dead.svg"],
+            "image": ["https://i.pinimg.com/originals/fc/e0/0a/fce00a744394654ea05c69fa4ca54096"],
             "mainEntityOfPage": { "@type": "WebPage", "@id": "https://diwakaryadav.com.np/blog/is-prompt-engineering-dead/" },
             "datePublished": "2026-06-26",
             "dateModified": "2026-08-09",

--- a/blog/open-vs-closed-models/index.html
+++ b/blog/open-vs-closed-models/index.html
@@ -67,7 +67,7 @@
     <meta property="og:description" content="A practical decision guide for choosing open-weight vs closed AI models in 2026, based on cost, privacy, control, and what you actually ship.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://diwakaryadav.com.np/blog/open-vs-closed-models/">
-    <meta property="og:image" content="https://diwakaryadav.com.np/images/blog-open-vs-closed-models.svg">
+    <meta property="og:image" content="https://i.pinimg.com/originals/e4/b7/a1/e4b7a140fe7b7c584b5abeb36372754f">
     <meta property="og:image:alt" content="Open-Weight vs Closed AI Models: Which Should You Actually Use?">
     <meta property="article:published_time" content="2026-05-10">
     <meta property="article:modified_time" content="2026-08-09">
@@ -77,7 +77,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Open-Weight vs Closed AI Models: Which Should You Actually Use?">
     <meta name="twitter:description" content="A practical decision guide for choosing open-weight vs closed AI models in 2026, based on cost, privacy, control, and what you actually ship.">
-    <meta name="twitter:image" content="https://diwakaryadav.com.np/images/blog-open-vs-closed-models.svg">
+    <meta name="twitter:image" content="https://i.pinimg.com/originals/e4/b7/a1/e4b7a140fe7b7c584b5abeb36372754f">
 
     <script type="application/ld+json">
         {
@@ -86,7 +86,7 @@
             "headline": "Open-Weight vs Closed AI Models: Which Should You Actually Use?",
             "alternativeHeadline": "The open vs closed debate is mostly noise. Here is how I decide, based on what I ship.",
             "description": "A practical decision guide for choosing open-weight vs closed AI models in 2026, based on cost, privacy, control, and what you actually ship.",
-            "image": ["https://diwakaryadav.com.np/images/blog-open-vs-closed-models.svg"],
+            "image": ["https://i.pinimg.com/originals/e4/b7/a1/e4b7a140fe7b7c584b5abeb36372754f"],
             "mainEntityOfPage": { "@type": "WebPage", "@id": "https://diwakaryadav.com.np/blog/open-vs-closed-models/" },
             "datePublished": "2026-05-10",
             "dateModified": "2026-08-09",

--- a/blog/prompting-tips/index.html
+++ b/blog/prompting-tips/index.html
@@ -111,7 +111,7 @@
  content="Learn practical prompt engineering techniques for clearer AI outputs, better reasoning, and fewer hallucinations.">
  <meta property="og:type" content="article">
  <meta property="og:url" content="https://diwakaryadav.com.np/blog/prompting-tips/">
- <meta property="og:image" content="https://diwakaryadav.com.np/images/blog-prompting-tips.svg">
+ <meta property="og:image" content="https://i.pinimg.com/originals/23/03/a6/2303a67089c546ffbfb512fc21bd6958">
  <meta property="og:image:alt" content="12 AI prompting tips by Diwakar Ray Yadav">
  <meta property="article:published_time" content="2024-12-01">
  <meta property="article:modified_time" content="2026-03-20">
@@ -125,7 +125,7 @@
  <meta name="twitter:title" content="12 AI Prompting Tips for Better ChatGPT and Claude Results">
  <meta name="twitter:description"
  content="Learn practical prompt engineering techniques for clearer AI outputs, better reasoning, and fewer hallucinations.">
- <meta name="twitter:image" content="https://diwakaryadav.com.np/images/blog-prompting-tips.svg">
+ <meta name="twitter:image" content="https://i.pinimg.com/originals/23/03/a6/2303a67089c546ffbfb512fc21bd6958">
 
  <script type="application/ld+json">
  {
@@ -135,7 +135,7 @@
  "alternativeHeadline": "12 AI Prompting Tips: Stop Talking to AI Like a Bot",
  "description": "Learn 12 practical AI prompting tips to get better results from ChatGPT, Claude, and other AI assistants.",
  "image": [
- "https://diwakaryadav.com.np/images/blog-prompting-tips.svg"
+ "https://i.pinimg.com/originals/23/03/a6/2303a67089c546ffbfb512fc21bd6958"
  ],
  "mainEntityOfPage": {
  "@type": "WebPage",

--- a/blog/run-llm-locally/index.html
+++ b/blog/run-llm-locally/index.html
@@ -67,7 +67,7 @@
     <meta property="og:description" content="A beginner-friendly tutorial for running a real LLM on a normal laptop with no graphics card, using Ollama and a quantized model.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://diwakaryadav.com.np/blog/run-llm-locally/">
-    <meta property="og:image" content="https://diwakaryadav.com.np/images/blog-run-llm-locally.svg">
+    <meta property="og:image" content="https://i.pinimg.com/originals/b5/ce/73/b5ce7371503ba2673115ef209e0e4052">
     <meta property="og:image:alt" content="How to Run an LLM on a Normal Laptop (No GPU, No PhD)">
     <meta property="article:published_time" content="2026-05-25">
     <meta property="article:modified_time" content="2026-08-09">
@@ -77,7 +77,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="How to Run an LLM on a Normal Laptop (No GPU, No PhD)">
     <meta name="twitter:description" content="A beginner-friendly tutorial for running a real LLM on a normal laptop with no graphics card, using Ollama and a quantized model.">
-    <meta name="twitter:image" content="https://diwakaryadav.com.np/images/blog-run-llm-locally.svg">
+    <meta name="twitter:image" content="https://i.pinimg.com/originals/b5/ce/73/b5ce7371503ba2673115ef209e0e4052">
 
     <script type="application/ld+json">
         {
@@ -86,7 +86,7 @@
             "headline": "How to Run an LLM on a Normal Laptop (No GPU, No PhD)",
             "alternativeHeadline": "You do not need a $3,000 graphics card. You need the right model and about ten minutes.",
             "description": "A beginner-friendly tutorial for running a real LLM on a normal laptop with no graphics card, using Ollama and a quantized model.",
-            "image": ["https://diwakaryadav.com.np/images/blog-run-llm-locally.svg"],
+            "image": ["https://i.pinimg.com/originals/b5/ce/73/b5ce7371503ba2673115ef209e0e4052"],
             "mainEntityOfPage": { "@type": "WebPage", "@id": "https://diwakaryadav.com.np/blog/run-llm-locally/" },
             "datePublished": "2026-05-25",
             "dateModified": "2026-08-09",

--- a/blog/trending-llms/index.html
+++ b/blog/trending-llms/index.html
@@ -147,7 +147,7 @@
  content="A practical list of free AI tools and agent platforms with generous free tiers, reviewed for 2026.">
  <meta property="og:type" content="article">
  <meta property="og:url" content="https://diwakaryadav.com.np/blog/trending-llms/">
- <meta property="og:image" content="https://diwakaryadav.com.np/images/blog-ai-tools-2026.svg">
+ <meta property="og:image" content="https://i.pinimg.com/originals/2c/52/5f/2c525f08e83bb1a1989df8fd69ecf5f8">
  <meta property="og:image:alt" content="Best free AI tools, LLMs, and agent platforms in 2026">
  <meta property="article:published_time" content="2026-02-13">
  <meta property="article:modified_time" content="2026-04-29">
@@ -161,7 +161,7 @@
  <meta name="twitter:title" content="Best Free AI Tools, LLMs, and Agent Platforms in 2026">
  <meta name="twitter:description"
  content="A practical list of free AI tools and agent platforms with generous free tiers, reviewed for 2026.">
- <meta name="twitter:image" content="https://diwakaryadav.com.np/images/blog-ai-tools-2026.svg">
+ <meta name="twitter:image" content="https://i.pinimg.com/originals/2c/52/5f/2c525f08e83bb1a1989df8fd69ecf5f8">
 
  <script type="application/ld+json">
  {
@@ -170,7 +170,7 @@
  "headline": "Best Free AI Tools, LLMs, and Agent Platforms in 2026",
  "description": "A practical list of free AI tools, LLMs, and agent platforms in 2026, including chatbots, OCR tools, research agents, and workflow assistants.",
  "image": [
- "https://diwakaryadav.com.np/images/blog-ai-tools-2026.svg"
+ "https://i.pinimg.com/originals/2c/52/5f/2c525f08e83bb1a1989df8fd69ecf5f8"
  ],
  "mainEntityOfPage": {
  "@type": "WebPage",

--- a/blog/what-are-ai-agents/index.html
+++ b/blog/what-are-ai-agents/index.html
@@ -67,7 +67,7 @@
     <meta property="og:description" content="A plain-language explanation of what AI agents are, how they differ from chatbots, and why they are reshaping how software gets built.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://diwakaryadav.com.np/blog/what-are-ai-agents/">
-    <meta property="og:image" content="https://diwakaryadav.com.np/images/blog-what-are-ai-agents.svg">
+    <meta property="og:image" content="https://i.pinimg.com/originals/f8/ec/8a/f8ec8a634ba7c7db84c1e0de011ec1e0">
     <meta property="og:image:alt" content="AI Agents Are Quietly Breaking the Old 'App' Model">
     <meta property="article:published_time" content="2026-06-10">
     <meta property="article:modified_time" content="2026-08-09">
@@ -77,7 +77,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="AI Agents Are Quietly Breaking the Old 'App' Model">
     <meta name="twitter:description" content="A plain-language explanation of what AI agents are, how they differ from chatbots, and why they are reshaping how software gets built.">
-    <meta name="twitter:image" content="https://diwakaryadav.com.np/images/blog-what-are-ai-agents.svg">
+    <meta name="twitter:image" content="https://i.pinimg.com/originals/f8/ec/8a/f8ec8a634ba7c7db84c1e0de011ec1e0">
 
     <script type="application/ld+json">
         {
@@ -86,7 +86,7 @@
             "headline": "AI Agents Are Quietly Breaking the Old 'App' Model",
             "alternativeHeadline": "We spent a decade building apps with buttons. Agents trade the buttons for goals. That changes everything.",
             "description": "A plain-language explanation of what AI agents are, how they differ from chatbots, and why they are reshaping how software gets built.",
-            "image": ["https://diwakaryadav.com.np/images/blog-what-are-ai-agents.svg"],
+            "image": ["https://i.pinimg.com/originals/f8/ec/8a/f8ec8a634ba7c7db84c1e0de011ec1e0"],
             "mainEntityOfPage": { "@type": "WebPage", "@id": "https://diwakaryadav.com.np/blog/what-are-ai-agents/" },
             "datePublished": "2026-06-10",
             "dateModified": "2026-08-09",


### PR DESCRIPTION
Replaces emoji card thumbnails with topic-matched Pinterest hotlinks (warm/editorial palette). Updates og:image + twitter:image + JSON-LD image URLs for all 11 posts in sync.

Also fixes a dark/light toggle bug on /blog/: the inline :root (light) variables were being overridden by @media (prefers-color-scheme: dark) { :root } from the external CSS because both had specificity 0,1,0. Fix: bump inline selector to ':root, html[data-theme="light"]' (now 0,1,1) so an explicit light toggle wins.

All 11 cards verified to load via the browser test.